### PR TITLE
Entity Change - ToField trait. Add Bytes, BigInt, and BigDecimal implentations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.1.1]
+
+* Added implementations on the ToField trait used by the EntityChange struct for BigInt, BigDecimal, and Bytes arrays. 
+
 ## [1.1.0]
 
 ### Deprecation

--- a/substreams.yaml
+++ b/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: substreams_entity_change
-  version: v0.1.0
+  version: v0.1.1
   url: https://github.com/streamingfast/substreams-entity-change
   doc: |
     Protobuf definitions for Substreams Entity Change modules.


### PR DESCRIPTION
**Context**
Our GraphQL schema for substreams includes Bytes, BigInt, and BigDecimal arrays. In order to update these values using the EntityChange struct, the ToField trait needs to be updated to include implementations for the types. This PR adds implementations and includes tests for them as well. All tests are passing. 
